### PR TITLE
Add window default vals, change find-start min_period parameter

### DIFF
--- a/sigmet/au3_functions.py
+++ b/sigmet/au3_functions.py
@@ -78,10 +78,8 @@ def find_start(series, user_start, user_end, ma_window=6):
     assert(ma_window > 0, "Moving average window cannot be less than 1")
     # filter series to window between start and end date, smooth moving average
     # NOTE: we inclusively filter with user_start b/c when we run the differencing it will no longer be part of the series
-    filtered_series = series.rolling(ma_window).mean().loc[(
+    filtered_series = series.rolling(ma_window, min_periods=1).mean().loc[(
         series.index >= user_start) & (series.index < user_end)]
-    if filtered_series.hasnans:
-        raise ValueError("Moving average value too large for search window. Decrease the moving_average value or increase the size of the search window.")
 
     # special case if monotonic decreasing, want to check for largest first derivative
     if filtered_series.is_monotonic_decreasing:

--- a/sigmet/sigmet.py
+++ b/sigmet/sigmet.py
@@ -11,7 +11,7 @@ class Sigmet:
         # self.end_point = end_point
         self.data = data
 
-    def fit(self, window_start, window_end, sarimax_params=(5, 1, 1), standardize=False, moving_average=1, force_start=False, recovery_threshold=0.9):
+    def fit(self, window_start=None, window_end=None, sarimax_params=(5, 1, 1), standardize=False, moving_average=1, force_start=False, recovery_threshold=0.9):
         """
         Fits the model and returns a score representing the magnitude of the largest negative shock in the window.
 
@@ -47,7 +47,11 @@ class Sigmet:
         """
 
         srs = self.data.copy(deep=True)
-
+        
+        if window_start == None:
+            window_start = self.data.index[0]
+        if window_end == None:
+            window_end = self.data.index[-1]
         if standardize == True:
             srs = standardize(srs)
 


### PR DESCRIPTION
Set following params to default as follows:

- window_start = first date of data
- window_end = last date of data

Changed .rolling() behavior in find_start with min_periods parameter:
[https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.rolling.html](url)
min_periods sets rolling window size, so if equal to 1 no NaNs in series regardless of ma_window.
Users can focus on setting moving average window size according to expected recession period without focusing on fitting issues. Please comment on what you think of setting find_start behavior this way, i.e. potential situations where would not be ideal.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agupta01/sigmet/pull/33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
